### PR TITLE
hashicorp move their repo

### DIFF
--- a/vault/vault.xml
+++ b/vault/vault.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0"?>
 <Container version="2">
   <Name>vault</Name>
-  <Repository>vault</Repository>
-  <Registry>https://hub.docker.com/_/vault</Registry>
+  <Repository>hashicorp/vault</Repository>
+  <Registry>https://hub.docker.com/r/hashicorp/vault</Registry>
   <Network>bridge</Network>
   <MyIP/>
   <Shell>sh</Shell>


### PR DESCRIPTION
hashicorp move their repo from the official library to a new repo https://hub.docker.com/r/hashicorp/vault